### PR TITLE
/v1/users?me=1 now includes the session used to make the request, which

### DIFF
--- a/synchrony/controllers/dht.py
+++ b/synchrony/controllers/dht.py
@@ -813,6 +813,11 @@ class SynchronyProtocol(object):
         gevent.joinall(threads)
         threads = [t.value for t in threads]
         for response in threads:
+            # Every type of scenario here is useful
+            # If a peer was unresponsive then it tells us we have a peer to remove,
+            # if a peer serves content that doesn't match the hash we went for then
+            # there's a trust rating to adjust
+            # and if we hit upon the content we're after then the sooner the better.
             if response and response.status_code != 200:
                 continue
             revision = Revision()

--- a/synchrony/controllers/usergroups.py
+++ b/synchrony/controllers/usergroups.py
@@ -26,11 +26,13 @@ def init_user_groups():
     """
     # Bans happen by setting User.active to False and clearing their existing sessions.
     groups = ["Administrators", "Users"]
-    privs  = [ "see_all", "delete_at_will", "reset_user_pw", "modify_usergroup",
-               "deactivate", "manage_networks", "review_downloads", 
-               "create_revision_group", "delete_revision_group", "chat",
-               "initiate_rtc", "create_revision", "retrieve_from_dht", 
-               "browse_peer_nodes", "retrieve_resource", "stream_document"]
+    admin_privs  = [ "see_all", "delete_at_will", "reset_user_pw", "modify_usergroup",
+                     "deactivate", "manage_networks", "review_downloads"] 
+    privs        = [ "create_revision_group", "delete_revision_group", "chat",
+                     "initiate_rtc", "create_revision", "retrieve_from_dht", 
+                     "browse_peer_nodes", "retrieve_resource", "stream_document"]
+
+    privs.extend(admin_privs)
 
     if not Priv.query.first():
         log("Creating privileges.")
@@ -47,9 +49,7 @@ def init_user_groups():
         if not g:
             g = UserGroup(name=group)
             for p in Priv.query.all():
-                if group != "Administrators" and p.name in \
-                        ["see_all", "delete_at_will", "reset_user_pw", "modify_usergroup",
-                         "deactivate", "manage_networks", "review_downloads"]:
+                if group != "Administrators" and p.name in admin_privs:
                     continue
                 a         = Acl()
                 a.group   = g

--- a/synchrony/resources/networks.py
+++ b/synchrony/resources/networks.py
@@ -17,8 +17,16 @@ class NetworkCollection(restful.Resource):
         parser.add_argument("per_page", type=int, required=False, default=10)
         args = parser.parse_args()
 
-        pages = Pagination(app.routes.values(), args.page, args.per_page)
-        return make_response(request.url, pages)
+        routes      = app.routes.values()
+        pages       = Pagination(routes, args.page, args.per_page)
+        response    = make_response(request.url, pages)
+        peer_count  = 0
+
+        for router in routes:
+            peer_count   += len(router)
+        response['peers'] = peer_count
+
+        return response
 
         # If you're here because you're wondering what the "private" attribute
         # in the responses means: It's for networks composed of nodes who all

--- a/synchrony/resources/users.py
+++ b/synchrony/resources/users.py
@@ -26,7 +26,10 @@ class UserCollection(restful.Resource):
         args = parser.parse_args()
 
         if args.me:
-            return user.jsonify()
+            s = Session.query.filter(Session.session_id == session['session']).first()
+            response            = user.jsonify()
+            response['session'] = s.jsonify()
+            return response
 
         if not user.can("see_all"):
             return {}, 403
@@ -269,8 +272,8 @@ class UserFriendsCollection(restful.Resource):
         user = auth(session, required=True)
 
         parser = restful.reqparse.RequestParser()
-        parser.add_argument("page",type=int, help="", required=False, default=1)
-        parser.add_argument("per_page",type=int, help="", required=False, default=10)
+        parser.add_argument("page",     type=int, default=1)
+        parser.add_argument("per_page", type=int, default=10)
         args = parser.parse_args()  
 
         if user.username != username and not user.can("see_all"):
@@ -290,8 +293,9 @@ class UserFriendsCollection(restful.Resource):
         user = auth(session, required=True)
 
         parser = reqparse.RequestParser()
-        parser.add_argument("add", type=str)
-        parser.add_argument("remove", type=str)
+        parser.add_argument("add",     type=bool)
+        parser.add_argument("remove",  type=bool)
+        parser.add_argument("address", type=str, required=True)
         args = parser.parse_args()
 
         return {}

--- a/synchrony/static/templates/peers.tmpl
+++ b/synchrony/static/templates/peers.tmpl
@@ -1,7 +1,7 @@
 <div class="view">
     <h1>Peers and Downloads</h1>
     <hr />
-    {{#peers.length}}
+    {{#peers_permitted}}
     <h2>Peer Browser<button on-click="toggle:{{"peers"}}" class="button big_button pull-right">{{peers_button}}</button></h2>
     {{#showing_peers}}
             <table>
@@ -16,8 +16,9 @@
                 </tbody>
             </table>
     {{/showing_peers}}
-    {{/peers.length}}
+    {{/peers_permitted}}
 
+    {{#downloads_permitted}}
     <h2>Downloads<button on-click="toggle:{{"downloads"}}" class="button big_button pull-right">{{downloads_button}}</button></h2>
     {{#showing_downloads}}
     {{#selection}}
@@ -77,4 +78,5 @@
         </table>
     {{/downloads}}
     {{/showing_downloads}}
+    {{/downloads_permitted}}
 </div>


### PR DESCRIPTION
fixes using the logout button from a session with the program where
you'd logged in previously.

Modified synchrony.controllers.usergroups for readability.

The peers view now requires the associated privs before its sections can
be viewed.
