### PR TITLE
Introduces /v1/peers/<string:network> which is a paginated way of

### DIFF
--- a/synchrony/__init__.py
+++ b/synchrony/__init__.py
@@ -128,6 +128,7 @@ def init():
     api.add_resource(users.UserRevisionCollection,          "/users/<string:username>/revisions")
 
     api.add_resource(peers.PeerCollection,                  "/peers")
+    api.add_resource(peers.PeerNetworkResource,             "/peers/<string:network>")
     api.add_resource(peers.PeerResource,                    "/peers/<string:network>/<int:node_id>")
     api.add_resource(peers.PublicRevisionCollection,        "/peers/revisions")
     api.add_resource(peers.PublicRevisionResource,          "/peers/revisions/<string:content_hash>")

--- a/synchrony/resources/peers.py
+++ b/synchrony/resources/peers.py
@@ -106,6 +106,29 @@ class PeerCollection(restful.Resource):
 
         return response
 
+class PeerNetworkResource(restful.Resource):
+    """
+    A paginated collection of peers via network name.
+    """
+
+    def get(self, network):
+        parser = restful.reqparse.RequestParser()
+        parser.add_argument("page",     type=int, default=1)
+        parser.add_argument("per_page", type=int, default=10)
+        args = parser.parse_args()
+
+        routes = app.routes.get(network, None)
+        if not routes:
+            return {}, 404
+
+        peers    = [peer for peer in routes]
+        pages    = Pagination(peers, args.page, args.per_page)
+        response = routes.jsonify()
+
+        response.update(make_response(request.url, pages))
+
+        return response
+
 class PeerResource(restful.Resource):
     """
     Defines a resource for returning a specific peer by node ID.


### PR DESCRIPTION
leafing through peers by network name. Useful for the Peer Browser on
the frontend and probably necessary for implementing EigenTrust.
